### PR TITLE
Add GitHub Pages live demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: examples/v3-book/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: examples/v3-book
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build demo
+        run: npm run build -- --base "${{ steps.pages.outputs.base_path }}/"
+        working-directory: examples/v3-book
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: examples/v3-book/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A style-neutral Codex skill that turns raw photo collections or finished pages into curated, page-turning photo books using raw HTML, CSS, and vanilla JavaScript.
 
+**[▶ Live Demo](https://haichaolihc.github.io/create-photo-flipbook-ui/)** — Interactive 3D photo flipbook
+
 The skill inspects the collection, chooses compatible visual photo skills, curates the strongest images, designs the sequence and rhythm, generates complete spreads, and assembles the accepted artwork into a responsive 3D flipbook.
 
 ![Death Valley photo book open to a generated spread](docs/images/death-valley-flipbook.jpg)

--- a/examples/v3-book/src/main.js
+++ b/examples/v3-book/src/main.js
@@ -151,7 +151,8 @@ function pageMaterial(bookId, source) {
   const cache = cacheForBook(bookId);
   if (cache.has(source)) return cache.get(source);
 
-  const request = textureLoader.loadAsync(source).then((texture) => {
+  const assetUrl = `${import.meta.env.BASE_URL}${source.replace(/^\/+/, "")}`;
+  const request = textureLoader.loadAsync(assetUrl).then((texture) => {
     resizeTextureImage(texture);
     texture.colorSpace = THREE.SRGBColorSpace;
     texture.anisotropy = Math.min(

--- a/examples/v3-book/src/quick-flipbook-contract.test.mjs
+++ b/examples/v3-book/src/quick-flipbook-contract.test.mjs
@@ -67,9 +67,11 @@ test("the loading live region is removed from the accessibility tree when idle",
   assert.match(main, /loadingCopy\.textContent = value \? copy : ""/);
 });
 
-test("v3 exposes five editions and owns its public asset library", () => {
+test("v3 owns its public asset library and respects the deployment base path", () => {
   assert.equal((books.match(/id: "/g) || []).length, 5);
   assert.match(config, /publicDir: "public"/);
+  assert.match(main, /const assetUrl = `\$\{import\.meta\.env\.BASE_URL\}/);
+  assert.match(main, /textureLoader\.loadAsync\(assetUrl\)/);
 });
 
 test("v3 keeps the interface silent and the stage white", () => {


### PR DESCRIPTION
## Summary

- publish the existing `examples/v3-book` photo book demo through GitHub Pages
- make its runtime photo URLs respect the Pages repository base path
- add a prominent Live Demo link near the top of the README

This keeps the existing demo and project design intact; there is no unrelated refactor or redesign.

## Validation

- `npm test` (21 tests)
- `npm run build -- --base /create-photo-flipbook-ui/`
- desktop and 390×844 mobile browser checks against the production build
- verified the page controls and all five editions
- verified all 53 HTML, JS, CSS, and photo requests returned 200 under `/create-photo-flipbook-ui/`

## One-time repository setting

GitHub Pages is not currently enabled for this repository. After merging, a maintainer may need to select **Settings → Pages → Build and deployment → Source → GitHub Actions** once. The checked-in workflow handles subsequent deployments from `main`.
